### PR TITLE
Mybinder support (python2 only for now)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM andrewosh/binder-base
+
+# for use with mybinder.org
+
+MAINTAINER Hanno Rein  <hanno@hanno-rein.de>
+
+USER root
+COPY . $HOME/
+
+
+RUN pip install rebound
+RUN pip install -v -e .

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@
     :target: https://github.com/dtamayo/reboundx/blob/master/LICENSE
 .. image:: https://readthedocs.org/projects/pip/badge/?version=latest
     :target: http://reboundx.readthedocs.org/
+.. image:: https://img.shields.io/badge/launch-binder-ff69b4.svg?style=flat
+    :target: http://mybinder.org/repo/dtamayo/reboundx
 
 Update: New Version!
 ====================


### PR DESCRIPTION
I can't figure out how to install the packages for python 3. It might be something related to anaconda. But if you switch the kernel to python2 in the notebooks, it works!