### PR TITLE
Updated speed of light to be consistent with the units used in rebound

### DIFF
--- a/reboundx/constants.py
+++ b/reboundx/constants.py
@@ -2,5 +2,5 @@
 These are constants in REBOUND default units of AU, solar masses and (yr/2pi), in which case G=1
 """
 
-C= 10064.915 # speed of light
+C= 10065.32012038219 # speed of light
 


### PR DESCRIPTION
I think the old value was slightly off (don't know why). 