### PR TITLE
removed unused numpy import

### DIFF
--- a/reboundx/params.py
+++ b/reboundx/params.py
@@ -8,7 +8,6 @@ from .extras import Param, Node, Force, Operator, Extras, REBX_CTYPES
 from . import clibreboundx
 from ctypes import byref, c_double, c_int, c_int32, c_int64, c_uint, c_uint32, c_longlong, c_char_p, POINTER, cast
 from ctypes import c_void_p, memmove, sizeof, addressof
-import numpy as np
 from rebound.tools import hash as rebhash
 
 class Params(MutableMapping):


### PR DESCRIPTION
I don't think numpy is used anywhere expect in the tests, so the import statement can probably be removed from params.py.