### PR TITLE
New vec3d class

### DIFF
--- a/reboundx/extras.py
+++ b/reboundx/extras.py
@@ -228,9 +228,8 @@ class Extras(Structure):
         Returns a list of the three (x,y,z) components of the spin angular momentum of all particles in the simulation with
         moment of inertia (I) and spin angular frequency vector (Omega) parameters set.
         """
-        clibreboundx.rebx_spin_angular_momentum.restype = rebound.Vec3d
-        L = clibreboundx.rebx_spin_angular_momentum(byref(self))
-        return [L.x, L.y, L.z]
+        clibreboundx.rebx_spin_angular_momentum.restype = rebound._Vec3d
+        return rebound.Vec3d(clibreboundx.rebx_spin_angular_momentum(byref(self)))
 
     def process_messages(self):
         try:
@@ -367,7 +366,7 @@ Interpolator._fields_ = [  ("interpolation", c_int),
 INTERPOLATION_TYPE = {"none":0, "spline":1}
 
 # This list keeps pairing from C rebx_param_type enum to ctypes type 1-to-1. Derive the required mappings from it
-REBX_C_TO_CTYPES = [["REBX_TYPE_NONE", None], ["REBX_TYPE_DOUBLE", c_double], ["REBX_TYPE_INT",c_int], ["REBX_TYPE_POINTER", c_void_p], ["REBX_TYPE_FORCE", Force], ["REBX_TYPE_UNIT32", c_uint32], ["REBX_TYPE_ORBIT", rebound.Orbit], ["REBX_TYPE_ODE", rebound.ODE], ["REBX_TYPE_VEC3D", rebound.Vec3d]]
+REBX_C_TO_CTYPES = [["REBX_TYPE_NONE", None], ["REBX_TYPE_DOUBLE", c_double], ["REBX_TYPE_INT",c_int], ["REBX_TYPE_POINTER", c_void_p], ["REBX_TYPE_FORCE", Force], ["REBX_TYPE_UNIT32", c_uint32], ["REBX_TYPE_ORBIT", rebound.Orbit], ["REBX_TYPE_ODE", rebound.ODE], ["REBX_TYPE_VEC3D", rebound._Vec3d]]
 REBX_CTYPES = {} # maps int value of rebx_param_type enum to ctypes type
 REBX_C_PARAM_TYPES = {} # maps string of rebx_param_type enum to int
 for i, pair in enumerate(REBX_C_TO_CTYPES):

--- a/reboundx/params.py
+++ b/reboundx/params.py
@@ -45,8 +45,8 @@ class Params(MutableMapping):
             val = valptr.contents.value # return python int or float rather than c_int or c_double
         except AttributeError:
             val = valptr.contents # Structure, return ctypes object
-            if isinstance(val, rebound.Vec3d):
-                return [val.x, val.y, val.z]
+            if isinstance(val, rebound._Vec3d):
+                return rebound.Vec3d(val)
         except ValueError: # NULL access
             raise AttributeError("REBOUNDx Error: Parameter '{0}' not found on object.".format(key))
 
@@ -63,8 +63,8 @@ class Params(MutableMapping):
             clibreboundx.rebx_set_param_int(self.rebx, byref(self.ap), c_char_p(key.encode('ascii')), c_int(value))
         if ctype == c_uint32:
             clibreboundx.rebx_set_param_uint32(self.rebx, byref(self.ap), c_char_p(key.encode('ascii')), value)
-        if ctype == rebound.Vec3d:
-            clibreboundx.rebx_set_param_vec3d(self.rebx, byref(self.ap), c_char_p(key.encode('ascii')), rebound.Vec3d(value))
+        if ctype == rebound._Vec3d:
+            clibreboundx.rebx_set_param_vec3d(self.rebx, byref(self.ap), c_char_p(key.encode('ascii')), rebound.Vec3d(value)._vec3d)
         if ctype == Force:
             if not isinstance(value, Force):
                 raise AttributeError("REBOUNDx Error: Parameter '{0}' must be assigned a Force object.".format(key))


### PR DESCRIPTION
This is related to what I tried on [hannorein/rebound/new_reb3d](https://github.com/hannorein/rebound/tree/new_reb3d).

I don't think we will be able to find a workaround for the stupid numpy issue that prevents us from doing `numpy_array[1] = vec3d`. At the very best we might hope for a fix in a new version, but whatever we do needs to be compatible for old numpy versions for many years. 

In hannorein/rebound/new_reb3d, I simply created a new wrapper class `Vec3d` which is not a subclass of `ctypes.structure`. This way I can implement `__array_interface__`. The new `Vec3d` class has an attribute which of type `_Vec3d` - an internal class that *is* a subclass of `ctypes.Structure`. 

From a user point of view this doesn't change anything. But it does add one extra stumbling block when writing code that accesses the c library. Those functions need the `_Vec3d` object, not the `Vec3d` one. 

Have a look at the code an tell me what you think. 