### PR TITLE
fixed clang compiler error and warnings

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -575,7 +575,10 @@ int rebx_add_operator(struct rebx_extras* rebx, struct rebx_operator* operator){
                 reb_simulation_error(sim, "REBOUNDx Error: Operators that affect particle trajectories are not supported with Mercurius. Must add as forces.\n");
                 return 0;
             }
+            break;
         }
+        default:
+            break;
     }
     return 0; // didn't reach a successful outcome
 }
@@ -854,7 +857,7 @@ void rebx_free_ap(struct rebx_node** ap){
 }
 
 void rebx_free_particle_ap(struct reb_particle* p){
-    rebx_free_ap(&p->ap);
+    rebx_free_ap((struct rebx_node **)(&p->ap));
 }
 
 void rebx_free_force(struct rebx_extras* rebx, struct rebx_force* force){

--- a/src/exponential_migration.c
+++ b/src/exponential_migration.c
@@ -73,10 +73,10 @@ static struct  reb_vec3d rebx_calculate_modify_orbits_forces_new(struct reb_simu
     const double dvx = p->vx - source->vx;
     const double dvy = p->vy - source->vy;
     const double dvz = p->vz - source->vz;
-    const double dx = p->x-source->x;
-    const double dy = p->y-source->y;
-    const double dz = p->z-source->z;
-    const double r2 = dx*dx + dy*dy + dz*dz;
+    //const double dx = p->x-source->x;
+    //const double dy = p->y-source->y;
+    //const double dz = p->z-source->z;
+    //const double r2 = dx*dx + dy*dy + dz*dz;
     
     if(em_tau_a_ptr != NULL){
         em_tau_a = *em_tau_a_ptr;

--- a/src/gas_dynamical_friction.c
+++ b/src/gas_dynamical_friction.c
@@ -123,7 +123,7 @@ static void rebx_calculate_gas_dynamical_friction(struct reb_simulation* const s
         //scale height is defined by user-defined aspect ratio. Truncate the disc vertically
         //at 10 scale heights...
         const double h=hr*rcyl;
-        const double vert=(abs(diff.z)<(10*h))?exp(-diff.z*diff.z/(2.0*h*h)):0;
+        const double vert=(fabs(diff.z)<(10*h))?exp(-diff.z*diff.z/(2.0*h*h)):0;
         const double rhog_loc=rhog*pow(rcyl, alpha_rhog)*vert;
         const double mp = p.m;
         const double rstar = p.r;

--- a/src/gr_full.c
+++ b/src/gr_full.c
@@ -58,80 +58,82 @@
 #include "rebound.h"
 #include "reboundx.h"
 
-static void reb_particles_transform_inertial_to_barycentric_posvelacc(const struct reb_particle* const particles, struct reb_particle* const p_b, const unsigned int N, const unsigned int N_active){
-    double x0  = 0.;
-    double y0  = 0.;
-    double z0  = 0.;
-    double vx0 = 0.;
-    double vy0 = 0.;
-    double vz0 = 0.;
-    double ax0 = 0.;
-    double ay0 = 0.;
-    double az0 = 0.;
-    double m0  = 0.;
-#pragma omp parallel for reduction(+:x0) reduction(+:y0) reduction(+:z0) reduction(+:vx0) reduction(+:vy0) reduction(+:vz0) reduction(+:ax0) reduction(+:ay0) reduction(+:az0) reduction(+:m0)
-    for (unsigned int i=0;i<N_active;i++){
-        double m = particles[i].m;
-        x0  += particles[i].x *m;
-        y0  += particles[i].y *m;
-        z0  += particles[i].z *m;
-        vx0 += particles[i].vx*m;
-        vy0 += particles[i].vy*m;
-        vz0 += particles[i].vz*m;
-        ax0 += particles[i].ax*m;
-        ay0 += particles[i].ay*m;
-        az0 += particles[i].az*m;
-        m0  += m;
-    }
-    p_b[0].x  = x0/m0;
-    p_b[0].y  = y0/m0;
-    p_b[0].z  = z0/m0;
-    p_b[0].vx = vx0/m0;
-    p_b[0].vy = vy0/m0;
-    p_b[0].vz = vz0/m0;
-    p_b[0].ax = ax0/m0;
-    p_b[0].ay = ay0/m0;
-    p_b[0].az = az0/m0;
-    p_b[0].m = m0;
-    
-#pragma omp parallel for 
-    for (unsigned int i=1;i<N;i++){
-        p_b[i].x  = particles[i].x  - p_b[0].x;
-        p_b[i].y  = particles[i].y  - p_b[0].y;
-        p_b[i].z  = particles[i].z  - p_b[0].z;
-        p_b[i].vx = particles[i].vx - p_b[0].vx;
-        p_b[i].vy = particles[i].vy - p_b[0].vy;
-        p_b[i].vz = particles[i].vz - p_b[0].vz;
-        p_b[i].ax = particles[i].ax - p_b[0].ax;
-        p_b[i].ay = particles[i].ay - p_b[0].ay;
-        p_b[i].az = particles[i].az - p_b[0].az;
-        p_b[i].m  = particles[i].m;
-    }
-}
-
-static void reb_particles_transform_barycentric_to_inertial_acc(struct reb_particle* const particles, const struct reb_particle* const p_b, const unsigned int N, const unsigned int N_active){
-    const double mtot = p_b[0].m;
-    double ax0  = 0.;
-    double ay0  = 0.;
-    double az0  = 0.;
-#pragma omp parallel for reduction(+:ax0) reduction(+:ay0) reduction(+:az0) 
-    for (unsigned int i=1;i<N_active;i++){
-        double m = p_b[i].m;
-        ax0 += p_b[i].ax*m/mtot;
-        ay0 += p_b[i].ay*m/mtot;
-        az0 += p_b[i].az*m/mtot;
-        particles[i].m = m; // in case of merger/mass change
-    }
-    particles[0].ax  = p_b[0].ax - ax0;
-    particles[0].ay  = p_b[0].ay - ay0;
-    particles[0].az  = p_b[0].az - az0;
-#pragma omp parallel for 
-    for (unsigned int i=1;i<N;i++){
-        particles[i].ax = p_b[i].ax+particles[0].ax;
-        particles[i].ay = p_b[i].ay+particles[0].ay;
-        particles[i].az = p_b[i].az+particles[0].az;
-    }
-}
+// The following functions are not used.
+//
+//static void reb_particles_transform_inertial_to_barycentric_posvelacc(const struct reb_particle* const particles, struct reb_particle* const p_b, const unsigned int N, const unsigned int N_active){
+//    double x0  = 0.;
+//    double y0  = 0.;
+//    double z0  = 0.;
+//    double vx0 = 0.;
+//    double vy0 = 0.;
+//    double vz0 = 0.;
+//    double ax0 = 0.;
+//    double ay0 = 0.;
+//    double az0 = 0.;
+//    double m0  = 0.;
+//#pragma omp parallel for reduction(+:x0) reduction(+:y0) reduction(+:z0) reduction(+:vx0) reduction(+:vy0) reduction(+:vz0) reduction(+:ax0) reduction(+:ay0) reduction(+:az0) reduction(+:m0)
+//    for (unsigned int i=0;i<N_active;i++){
+//        double m = particles[i].m;
+//        x0  += particles[i].x *m;
+//        y0  += particles[i].y *m;
+//        z0  += particles[i].z *m;
+//        vx0 += particles[i].vx*m;
+//        vy0 += particles[i].vy*m;
+//        vz0 += particles[i].vz*m;
+//        ax0 += particles[i].ax*m;
+//        ay0 += particles[i].ay*m;
+//        az0 += particles[i].az*m;
+//        m0  += m;
+//    }
+//    p_b[0].x  = x0/m0;
+//    p_b[0].y  = y0/m0;
+//    p_b[0].z  = z0/m0;
+//    p_b[0].vx = vx0/m0;
+//    p_b[0].vy = vy0/m0;
+//    p_b[0].vz = vz0/m0;
+//    p_b[0].ax = ax0/m0;
+//    p_b[0].ay = ay0/m0;
+//    p_b[0].az = az0/m0;
+//    p_b[0].m = m0;
+//    
+//#pragma omp parallel for 
+//    for (unsigned int i=1;i<N;i++){
+//        p_b[i].x  = particles[i].x  - p_b[0].x;
+//        p_b[i].y  = particles[i].y  - p_b[0].y;
+//        p_b[i].z  = particles[i].z  - p_b[0].z;
+//        p_b[i].vx = particles[i].vx - p_b[0].vx;
+//        p_b[i].vy = particles[i].vy - p_b[0].vy;
+//        p_b[i].vz = particles[i].vz - p_b[0].vz;
+//        p_b[i].ax = particles[i].ax - p_b[0].ax;
+//        p_b[i].ay = particles[i].ay - p_b[0].ay;
+//        p_b[i].az = particles[i].az - p_b[0].az;
+//        p_b[i].m  = particles[i].m;
+//    }
+//}
+//
+//static void reb_particles_transform_barycentric_to_inertial_acc(struct reb_particle* const particles, const struct reb_particle* const p_b, const unsigned int N, const unsigned int N_active){
+//    const double mtot = p_b[0].m;
+//    double ax0  = 0.;
+//    double ay0  = 0.;
+//    double az0  = 0.;
+//#pragma omp parallel for reduction(+:ax0) reduction(+:ay0) reduction(+:az0) 
+//    for (unsigned int i=1;i<N_active;i++){
+//        double m = p_b[i].m;
+//        ax0 += p_b[i].ax*m/mtot;
+//        ay0 += p_b[i].ay*m/mtot;
+//        az0 += p_b[i].az*m/mtot;
+//        particles[i].m = m; // in case of merger/mass change
+//    }
+//    particles[0].ax  = p_b[0].ax - ax0;
+//    particles[0].ay  = p_b[0].ay - ay0;
+//    particles[0].az  = p_b[0].az - az0;
+//#pragma omp parallel for 
+//    for (unsigned int i=1;i<N;i++){
+//        particles[i].ax = p_b[i].ax+particles[0].ax;
+//        particles[i].ay = p_b[i].ay+particles[0].ay;
+//        particles[i].az = p_b[i].az+particles[0].az;
+//    }
+//}
 
 static void rebx_calculate_gr_full(struct reb_simulation* const sim, struct reb_particle* const particles, const int N, const double C2, const double G, const int max_iterations, const int gravity_ignore_10){
     
@@ -275,7 +277,7 @@ static void rebx_calculate_gr_full(struct reb_simulation* const sim, struct reb_
                     const double dzij = ps_b[i].z - ps_b[j].z;
                     const double rij = sqrt(dxij*dxij + dyij*dyij + dzij*dzij);
                     const double rij3 = rij*rij*rij;
-                    const dotproduct = dxij*ps_b[j].ax+dyij*ps_b[j].ay+dzij*ps_b[j].az;
+                    const double dotproduct = dxij*ps_b[j].ax+dyij*ps_b[j].ay+dzij*ps_b[j].az;
 
                     non_constx += (G*particles[j].m*dxij/rij3)*dotproduct/(2.*C2) + (7./(2.*C2))*G*particles[j].m*ps_b[j].ax/rij;
                     non_consty += (G*particles[j].m*dyij/rij3)*dotproduct/(2.*C2) + (7./(2.*C2))*G*particles[j].m*ps_b[j].ay/rij;
@@ -370,18 +372,19 @@ double rebx_gr_full_hamiltonian(struct rebx_extras* const rebx, const struct reb
             
             double vtildei2 = vtilde[i].x*vtilde[i].x + vtilde[i].y*vtilde[i].y + vtilde[i].z*vtilde[i].z;
             double A = (1. - 0.5*vtildei2/C2);
-            
-            double sumk = 0.;
-            for (int k=0;k<N;k++){
-                if (k!=i){
-                    struct reb_particle pk = particles[k];
-                    double xik = pk.x - pi.x;
-                    double yik = pk.y - pi.y;
-                    double zik = pk.z - pi.z;
-                    double rik = sqrt(xik*xik + yik*yik + zik*zik);
-                    sumk -= 2.*G*pk.m/rik;
-                }
-            }
+           
+            // The result of the following calculation is never used.
+            //double sumk = 0.;
+            //for (int k=0;k<N;k++){
+            //    if (k!=i){
+            //        struct reb_particle pk = particles[k];
+            //        double xik = pk.x - pi.x;
+            //        double yik = pk.y - pi.y;
+            //        double zik = pk.z - pi.z;
+            //        double rik = sqrt(xik*xik + yik*yik + zik*zik);
+            //        sumk -= 2.*G*pk.m/rik;
+            //    }
+            //}
             
             struct reb_vec3d dv_pn = {0.};
             for (int j=0;j<N;j++){

--- a/src/input.c
+++ b/src/input.c
@@ -376,7 +376,7 @@ static int rebx_load_particle(struct rebx_extras* rebx, FILE* inf, enum rebx_inp
         switch (field.type){
             case REBX_BINARY_FIELD_TYPE_PARAM_LIST:
             {
-                if (!rebx_load_list(rebx, REBX_BINARY_FIELD_TYPE_PARAM, &p->ap, inf, warnings)){
+                if (!rebx_load_list(rebx, REBX_BINARY_FIELD_TYPE_PARAM, (struct rebx_node **)(&p->ap), inf, warnings)){
                     return 0;
                 }
                 break;

--- a/src/output.c
+++ b/src/output.c
@@ -252,6 +252,9 @@ static void rebx_write_list(struct rebx_extras* rebx, enum rebx_binary_field_typ
                 rebx_write_step(rebx, current->object, of);
                 break;
             }
+            default:
+                // Should implement a check for other types here
+                break;
         }
         N--;
     }


### PR DESCRIPTION
This fixes #131 and a few other compiler warnings. 

There was quite a bit of unused code in `gr_full`. I've commented it out - which doesn't change any result - but I'm not sure if `gr_full` works as expected.